### PR TITLE
Bug Fix: Timesheet Options Specification

### DIFF
--- a/pytimesheetcalculator/calculator.py
+++ b/pytimesheetcalculator/calculator.py
@@ -51,16 +51,20 @@ class TimeSheetCalculator(base.BaseTimeSheetCalculator):
         self.display_date_summaries()
 
     def apply_timesheet_options(self, json_doc):
-        for option_name, option_value in six.iteritems(json_doc['options']):
-            if option_name.lower() == 'total_hours':
-                print(
-                    "*** Adjusting Default Active Hours from {0} to {1}"
-                    .format(
-                        self.config.runtime['options']['active_hours'],
-                        option_value
+        if 'options' in json_doc:
+            for option_name, option_value in six.iteritems(
+                json_doc['options']
+            ):
+                if option_name.lower() == 'total_hours':
+                    print(
+                        "*** Adjusting Default Active Hours from {0} to {1}"
+                        .format(
+                            self.config.runtime['options']['active_hours'],
+                            option_value
+                        )
                     )
-                )
-                self.config.runtime['options']['active_hours'] = option_value
+                    self.config.runtime[
+                        'options']['active_hours'] = option_value
 
     def detect_active_hours(self, json_doc):
         for job_date, data in six.iteritems(json_doc['dates']):
@@ -103,14 +107,28 @@ class TimeSheetCalculator(base.BaseTimeSheetCalculator):
                 job_id = jobs_on_date['id']
                 job_config = self.get_timecode_config(job_id)
                 if job_config is None:
-                    LOG.debug('Date Processing: Job ID {0} has no configuration'.format(job_id))
+                    LOG.debug(
+                        'Date Processing: Job ID {0} has no '
+                        'configuration'.format(
+                            job_id
+                        )
+                    )
                     continue
 
-                LOG.debug('Date Processing: JOB ID {0} - Configuration {1}'.format(job_id, job_config))
+                LOG.debug(
+                    'Date Processing: JOB ID {0} - Configuration {1}'.format(
+                        job_id,
+                        job_config
+                    )
+                )
 
                 hours = jobs_on_date['hours']
                 if job_config['counts_on_40']:
-                    LOG.debug('Date Processing: Adding {0} to job'.format(hours))
+                    LOG.debug(
+                        'Date Processing: Adding {0} to job'.format(
+                            hours
+                        )
+                    )
                     self.time_data['total_hours'] += hours
 
                 self.time_data['date_hours'][job_date]['total_hours'] += hours
@@ -120,7 +138,8 @@ class TimeSheetCalculator(base.BaseTimeSheetCalculator):
 
                 if job_id not in self.time_data['job_hours']:
                     LOG.debug(
-                        'Date Processing: Adding {0} to job_hours with {1} hours'.format(
+                        'Date Processing: Adding {0} to job_hours with '
+                        '{1} hours'.format(
                             job_id,
                             hours
                         )
@@ -131,11 +150,15 @@ class TimeSheetCalculator(base.BaseTimeSheetCalculator):
                     }
                 else:
                     LOG.debug(
-                        'Date Processing: Updating {0} in job_hours with {1} hours from {2} to {3}'.format(
+                        'Date Processing: Updating {0} in job_hours with {1}'
+                        ' hours from {2} to {3}'.format(
                             job_id,
                             hours,
                             self.time_data['job_hours'][job_id]['hours'],
-                            (self.time_data['job_hours'][job_id]['hours'] + hours)
+                            (
+                                self.time_data[
+                                    'job_hours'][job_id]['hours'] + hours
+                            )
                         )
                     )
                     self.time_data['job_hours'][job_id]['hours'] += hours
@@ -145,7 +168,11 @@ class TimeSheetCalculator(base.BaseTimeSheetCalculator):
             # data should be curated and it should be impossible to get
             # an invalid job_id
             LOG.debug('Job Processing: job id: {0}'.format(job_id))
-            LOG.debug('Job Processing: time codes: {0}'.format(self.config.time_codes))
+            LOG.debug(
+                'Job Processing: time codes: {0}'.format(
+                    self.config.time_codes
+                )
+            )
             hours_job_config = self.get_timecode_config(job_id)
             if hours_job_config is None:
                 continue
@@ -165,14 +192,22 @@ class TimeSheetCalculator(base.BaseTimeSheetCalculator):
                     )
                 )
                 LOG.debug(
-                    'Job Processing: Update total percentate from {0} by {1} to {2}'.format(
+                    'Job Processing: Update total percentate from {0} by {1}'
+                    ' to {2}'.format(
                         self.time_data['total_percentage'],
                         job_hours['percentage'],
-                        (self.time_data['total_percentage'] + job_hours['percentage'])
+                        (
+                            self.time_data[
+                                'total_percentage'] + job_hours['percentage']
+                        )
                     )
                 )
                 self.time_data['total_percentage'] += job_hours['percentage']
-                LOG.debug('Job Processing: Time Data - {0}'.format(self.time_data))
+                LOG.debug(
+                    'Job Processing: Time Data - {0}'.format(
+                        self.time_data
+                    )
+                )
 
     def display(self):
         for job_id in sorted(self.time_data['job_hours'].keys()):
@@ -233,7 +268,12 @@ class TimeSheetCalculator(base.BaseTimeSheetCalculator):
 
         for job_id in sorted(all_job_ids):
             job_config = self.get_timecode_config(job_id)
-            LOG.debug('Job ID {0} Configuration: {1}'.format(job_id, job_config))
+            LOG.debug(
+                'Job ID {0} Configuration: {1}'.format(
+                    job_id,
+                    job_config
+                )
+            )
 
             # .. note:: Since all_jobs_ids is built from the source for
             #   get_timecode_config is should be impossible to not get a

--- a/tests/base.py
+++ b/tests/base.py
@@ -12,7 +12,7 @@ class MockConfig(object):
                 }
             },
             'options': {},
-            'codes': [] 
+            'codes': []
         }
 
     def set_time_codes(self, time_codes):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -18,18 +18,22 @@ class TestCommonBase(base.TestBase):
 
     @ddt.data(
         [],
-        [ {'name': 'abc' } ],
-        [ {'name': 'cdefg' }, {'name': 'hijklmop'}]
+        [{'name': 'abc'}],
+        [{'name': 'cdefg'}, {'name': 'hijklmop'}]
     )
     def test_initialization(self, time_codes):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             self.mock_config.set_time_codes(time_codes)
             mok_config.return_value = self.mock_config
 
             instance = calc_base.BaseTimeSheetCalculator()
 
     def test_run_not_implemented(self):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             mok_config.return_value = self.mock_config
             instance = calc_base.BaseTimeSheetCalculator()
             with self.assertRaises(NotImplementedError):
@@ -37,12 +41,14 @@ class TestCommonBase(base.TestBase):
 
     @ddt.data(
         ([], 0),
-        ([ {'name': 'abc' } ], 3),
-        ([ {'name': 'cdefg' }, {'name': 'hijklmop'}], 8)
+        ([{'name': 'abc'}], 3),
+        ([{'name': 'cdefg'}, {'name': 'hijklmop'}], 8)
     )
     @ddt.unpack
     def test_detect_max_length(self, time_codes, expected_max_length):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             self.mock_config.set_time_codes(time_codes)
             mok_config.return_value = self.mock_config
 
@@ -59,7 +65,9 @@ class TestCommonBase(base.TestBase):
     )
     @ddt.unpack
     def test_get_timecode_config(self, time_codes, timecode_id, is_none):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             self.mock_config.set_time_codes(time_codes)
             mok_config.return_value = self.mock_config
 

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -20,7 +20,9 @@ class TestCalculator(base.TestBase):
         super(TestCalculator, self).tearDown()
 
     def test_instantiation(self):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             mok_config.return_value = self.mock_config
 
             obj = calculator.TimeSheetCalculator()
@@ -28,7 +30,9 @@ class TestCalculator(base.TestBase):
             self.assertEqual(obj.time_data, {})
 
     def test_run(self):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             with mock.patch(
                 'pytimesheetcalculator.calculator.TimeSheetCalculator.'
                 'apply_timesheet_options'
@@ -42,15 +46,18 @@ class TestCalculator(base.TestBase):
                         'calculate_hours'
                     ):
                         with mock.patch(
-                            'pytimesheetcalculator.calculator.TimeSheetCalculator.'
+                            'pytimesheetcalculator.calculator.'
+                            'TimeSheetCalculator.'
                             'display'
                         ):
                             with mock.patch(
-                                'pytimesheetcalculator.calculator.TimeSheetCalculator.'
+                                'pytimesheetcalculator.calculator.'
+                                'TimeSheetCalculator.'
                                 'display_available_codes'
                             ):
                                 with mock.patch(
-                                    'pytimesheetcalculator.calculator.TimeSheetCalculator.'
+                                    'pytimesheetcalculator.calculator.'
+                                    'TimeSheetCalculator.'
                                     'display_date_summaries'
                                 ):
                                     mok_config.return_value = self.mock_config
@@ -59,14 +66,31 @@ class TestCalculator(base.TestBase):
                                     obj.run({})
 
     @ddt.data(
-        ({'options': {}}, {'active_hours': 168, 'max_length': 0}),
-        ({'options': {'other_option': ''}}, {'active_hours': 168, 'max_length': 0}),
-        ({'options': {'total_hours': 40}}, {'active_hours': 40, 'max_length': 0}),
-        ({'options': {'Total_Hours': 80}}, {'active_hours': 80, 'max_length': 0}),
+        (
+            {},
+            {'active_hours': 168, 'max_length': 0}
+        ),
+        (
+            {'options': {}},
+            {'active_hours': 168, 'max_length': 0}
+        ),
+        (
+            {'options': {'other_option': ''}},
+            {'active_hours': 168, 'max_length': 0}),
+        (
+            {'options': {'total_hours': 40}},
+            {'active_hours': 40, 'max_length': 0}
+        ),
+        (
+            {'options': {'Total_Hours': 80}},
+            {'active_hours': 80, 'max_length': 0}
+        ),
     )
     @ddt.unpack
     def test_apply_timesheet_options(self, json_doc, applied_options):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             mok_config.return_value = self.mock_config
 
             default_runtime_options = {
@@ -88,14 +112,16 @@ class TestCalculator(base.TestBase):
             )
 
     @ddt.data(
-        ({'dates':{}}, {}),
-        ({'dates':{ "foobar": {'jobs': []}}}, {}),
-        ({'dates':{ "barfoo": {'jobs': [ {'hours': 0 }]}}}, {}),
-        ({'dates':{ "barfoo": {'jobs': [ {'id': 'world', 'hours': 28 }]}}}, {})
+        ({'dates': {}}, {}),
+        ({'dates': {"foobar": {'jobs': []}}}, {}),
+        ({'dates': {"barfoo": {'jobs': [{'hours': 0}]}}}, {}),
+        ({'dates': {"barfoo": {'jobs': [{'id': 'world', 'hours': 28}]}}}, {})
     )
     @ddt.unpack
     def test_detect_active_hours_empty_cases(self, json_doc, applied_options):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             mok_config.return_value = self.mock_config
             obj = calculator.TimeSheetCalculator()
             obj.detect_active_hours(json_doc)
@@ -105,13 +131,15 @@ class TestCalculator(base.TestBase):
             )
 
     def test_detect_active_hours_noncounting_hours(self):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             self.mock_config.time_codes = [
                 {
                     "name": "Active but uncounted time",
                     "id": "happy_hour",
                     "active": True,
-                    "counts_on_40":  False
+                    "counts_on_40": False
                 },
                 {
                     "name": "Active and counted",
@@ -155,18 +183,34 @@ class TestCalculator(base.TestBase):
 
     @ddt.data(
         (
-         {'dates': {}},
-         {'total_hours': 0, 'total_percentage': 0.0, 'date_hours': {}, 'job_hours': {}}
+            {'dates': {}},
+            {
+                'total_hours': 0,
+                'total_percentage': 0.0,
+                'date_hours': {},
+                'job_hours': {}
+            }
         ),
         (
-         {'dates': {'freebie': {'jobs': []}}},
-         {'total_hours': 0, 'total_percentage': 0.0, 'date_hours': {
-            'freebie': {'total_hours': 0, 'jobs': []}}, 'job_hours': {}}
+            {'dates': {'freebie': {'jobs': []}}},
+            {
+                'total_hours': 0,
+                'total_percentage': 0.0,
+                'date_hours': {
+                    'freebie': {
+                        'total_hours': 0,
+                        'jobs': []
+                    }
+                },
+                'job_hours': {}
+            }
         )
     )
     @ddt.unpack
     def test_calculate_hours_empty(self, json_doc, expected_time_data):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             mok_config.return_value = self.mock_config
             obj = calculator.TimeSheetCalculator()
             obj.calculate_hours(json_doc)
@@ -176,7 +220,9 @@ class TestCalculator(base.TestBase):
             )
 
     def test_calculate_hours_multidoc(self):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             mok_config.return_value = self.mock_config
             json_doc = {
                 'dates': {
@@ -185,7 +231,7 @@ class TestCalculator(base.TestBase):
                     }
                 }
             }
-            expected_time_data =  {
+            expected_time_data = {
                 'total_hours': 0,
                 'total_percentage': 0.0,
                 'date_hours': {
@@ -205,19 +251,31 @@ class TestCalculator(base.TestBase):
                 expected_time_data
             )
 
-
     @ddt.data(
         (
-         {'dates': {'freebie': {'jobs': [
-                {'id': 'foobar'}
-            ]}}},
-         {'total_hours': 0, 'total_percentage': 0.0, 'date_hours': {
-            'freebie': {'total_hours': 0, 'jobs': []}}, 'job_hours': {}}
+            {
+                'dates': {
+                    'freebie': {'jobs': [{'id': 'foobar'}]}
+                }
+            },
+            {
+                'total_hours': 0,
+                'total_percentage': 0.0,
+                'date_hours': {
+                    'freebie': {
+                        'total_hours': 0,
+                        'jobs': []
+                    }
+                },
+                'job_hours': {}
+            }
         )
     )
     @ddt.unpack
     def test_calculate_no_time_code_config(self, json_doc, expected_time_data):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             mok_config.return_value = self.mock_config
             obj = calculator.TimeSheetCalculator()
             obj.calculate_hours(json_doc)
@@ -228,21 +286,42 @@ class TestCalculator(base.TestBase):
 
     @ddt.data(
         (
-         {'dates': {'foils': {'jobs': [{'id': 'foobar', 'hours': 8, 'description': 'foo'}]}}},
-         {'total_hours': 8, 'total_percentage': 0.0, 'date_hours': {
-            'foils': {'total_hours': 8, 'jobs': [
-                {'id': 'foobar', 'hours': 8, 'description': 'foo'}
-            ]}},
-            'job_hours': {
-                'foobar': {'hours': 8, 'percentage': 0.0}
-            }}
+            {
+                'dates': {
+                    'foils': {
+                        'jobs': [
+                            {'id': 'foobar', 'hours': 8, 'description': 'foo'}
+                        ]
+                    }
+                }
+            },
+            {
+                'total_hours': 8,
+                'total_percentage': 0.0,
+                'date_hours': {
+                    'foils': {
+                        'total_hours': 8,
+                        'jobs': [
+                            {'id': 'foobar', 'hours': 8, 'description': 'foo'}
+                        ]
+                    }
+                },
+                'job_hours': {
+                    'foobar': {
+                        'hours': 8,
+                        'percentage': 0.0
+                    }
+                }
+            }
         )
     )
     @ddt.unpack
     def test_calculate_invalid_timecode_config_for_jobhour_calc(
         self, json_doc, expected_time_data
     ):
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             mok_config.return_value = self.mock_config
 
             with mock.patch(
@@ -262,43 +341,52 @@ class TestCalculator(base.TestBase):
                     obj.time_data,
                     expected_time_data
                 )
+
     @ddt.data(
         (
-         {
-            'dates': {
-                'foils': {
-                    'jobs': [
-                        {'id': 'foobar', 'hours': 8, 'description': 'foo'},
-                        {'id': 'foobar', 'hours': 8, 'description': 'bar'},
-                        {'id': 'd34db33f', 'hours': 8, 'description': 'foobar'}
-                    ]
-                }
-            }
-         },
-         {
-            'total_hours': 16,
-            'total_percentage': 100.0,
-            'date_hours': {
-                'foils': {
-                    'total_hours': 24,
-                    'jobs': [
-                        {'id': 'foobar', 'hours': 8, 'description': 'foo'},
-                        {'id': 'foobar', 'hours': 8, 'description': 'bar'},
-                        {'id': 'd34db33f', 'hours': 8, 'description': 'foobar'}
-                    ]
+            {
+                'dates': {
+                    'foils': {
+                        'jobs': [
+                            {'id': 'foobar', 'hours': 8, 'description': 'foo'},
+                            {'id': 'foobar', 'hours': 8, 'description': 'bar'},
+                            {
+                                'id': 'd34db33f',
+                                'hours': 8,
+                                'description': 'foobar'
+                            }
+                        ]
+                    }
                 }
             },
-            'job_hours': {
-                'd34db33f': {
-                    'hours': 8,
-                    'percentage': 0.0
+            {
+                'total_hours': 16,
+                'total_percentage': 100.0,
+                'date_hours': {
+                    'foils': {
+                        'total_hours': 24,
+                        'jobs': [
+                            {'id': 'foobar', 'hours': 8, 'description': 'foo'},
+                            {'id': 'foobar', 'hours': 8, 'description': 'bar'},
+                            {
+                                'id': 'd34db33f',
+                                'hours': 8,
+                                'description': 'foobar'
+                            }
+                        ]
+                    }
                 },
-                'foobar': {
-                    'hours': 16,
-                    'percentage': 100.0
+                'job_hours': {
+                    'd34db33f': {
+                        'hours': 8,
+                        'percentage': 0.0
+                    },
+                    'foobar': {
+                        'hours': 16,
+                        'percentage': 100.0
+                    }
                 }
             }
-         }
         )
     )
     @ddt.unpack
@@ -321,7 +409,9 @@ class TestCalculator(base.TestBase):
                 "counts_on_40": False
             }
         )
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             mok_config.return_value = self.mock_config
 
             obj = calculator.TimeSheetCalculator()
@@ -351,7 +441,9 @@ class TestCalculator(base.TestBase):
                 "counts_on_40": True
             },
         ]
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             mok_config.return_value = self.mock_config
 
             obj = calculator.TimeSheetCalculator()
@@ -404,7 +496,9 @@ class TestCalculator(base.TestBase):
             }
         ]
 
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             mok_config.return_value = self.mock_config
 
             obj = calculator.TimeSheetCalculator()
@@ -453,7 +547,9 @@ class TestCalculator(base.TestBase):
             }
         ]
 
-        with mock.patch('pytimesheetcalculator.config.Configuration') as mok_config:
+        with mock.patch(
+            'pytimesheetcalculator.config.Configuration'
+        ) as mok_config:
             mok_config.return_value = self.mock_config
 
             obj = calculator.TimeSheetCalculator()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,12 +42,13 @@ class TestConfig(base.TestBase):
             attr_value,
             getattr(obj, attr_name)
         )
-        
 
     @ddt.data(
         ({'runtime': {}, 'options': {}}, None),
         ({'runtime': {}, 'options': {}}, '/home/foo'),
-        ({'runtime': {}, 'options': {'default_total_hours': 200}}, '/home/bar'),
+        ({'runtime': {}, 'options': {'default_total_hours': 200}},
+         '/home/bar'
+         ),
     )
     @ddt.unpack
     def test_load(self, config_data, user_home_dir):


### PR DESCRIPTION
- Bug Fix: Calculator was incorrectly requiring the timesheet to
  have an `options` field even if not used.
- Bug Fix: Pep8 errors